### PR TITLE
.github: Split presubmits into build/verify/test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   build:
-    permissions:
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -32,6 +30,23 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Set up Go
+        uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
+        with:
+          go-version: 1.19
+          check-latest: true
+          cache: true
+
       - name: Check licenses
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,6 +54,23 @@ jobs:
 
       - name: Run verification
         run: make check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Set up Go
+        uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
+        with:
+          go-version: 1.19
+          check-latest: true
+          cache: true
 
       - name: Install required packages
         run: npm install @actions/core@1.6.0 @actions/http-client uuid@^3.3.3
@@ -75,6 +107,7 @@ jobs:
             const coredemo = require('@actions/core')
             let id_token = await coredemo.getIDToken("sigstore")   
             coredemo.setOutput('id_token', id_token)
+
       - name: KeylessTest
         if: always()
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,16 +6,24 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   build:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
         with:
           go-version: 1.19
           check-latest: true
@@ -36,7 +44,7 @@ jobs:
         run: npm install @actions/core@1.6.0 @actions/http-client uuid@^3.3.3
 
       - name: Generate uuid
-        uses: actions/github-script@v6
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
         id: get_uuid
         with:
           script: |
@@ -60,7 +68,7 @@ jobs:
 
       - name: Get IdToken
         if: always()
-        uses: actions/github-script@v6
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
         id: get_id_token
         with:
           script: |

--- a/.github/workflows/presubmits.yml
+++ b/.github/workflows/presubmits.yml
@@ -1,4 +1,4 @@
-name: build
+name: presubmits
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,21 @@ jobs:
     name: Release AWS Lambda
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Harden Runner
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
 
       - name: Set APP_VERSION env
         run: echo APP_VERSION=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> ${GITHUB_ENV}
       - name: Set BUILD_TIME env
         run: echo BUILD_TIME=$(date) >> ${GITHUB_ENV}
       - name: Environment Printer
-        uses: managedkaos/print-env@v1.0
+        uses: managedkaos/print-env@cc44fee1591e49c86931a4a7458926ec441a85dd
 
-      - uses: wangyoucao577/go-release-action@v1.16
+      - uses: wangyoucao577/go-release-action@d00bb7360b2dd6a39f1a7ca198b8289582eee2df
         with:
           goversion: https://go.dev/dl/go1.19.1.linux-amd64.tar.gz
           binary_name: aws_function
@@ -51,15 +56,20 @@ jobs:
           - goarch: "386"
             goos: darwin
     steps:
-      - uses: actions/checkout@v2
+      - name: Harden Runner
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
       - name: Set APP_VERSION env
         run: echo APP_VERSION=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> ${GITHUB_ENV}
       - name: Set BUILD_TIME env
         run: echo BUILD_TIME=$(date) >> ${GITHUB_ENV}
       - name: Environment Printer
-        uses: managedkaos/print-env@v1.0
+        uses: managedkaos/print-env@cc44fee1591e49c86931a4a7458926ec441a85dd
 
-      - uses: wangyoucao577/go-release-action@v1.16
+      - uses: wangyoucao577/go-release-action@d00bb7360b2dd6a39f1a7ca198b8289582eee2df
         with:
           goversion: https://go.dev/dl/go1.19.1.linux-amd64.tar.gz
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Several PRs (https://github.com/openclarity/functionclarity/pull/68, https://github.com/openclarity/functionclarity/pull/70, https://github.com/openclarity/functionclarity/pull/76) are failing due to e2es not working on forks.

This PR:

- .github: Harden workflows via https://app.stepsecurity.io/
- .github: Split presubmits into build/verify/test 

Failing tests have been segmented to the `test` step of `presubmits.yml` and they will be temporarily marked as non-blocking in advance of future fixes to enable non-maintainer contributions for the project.

Signed-off-by: Stephen Augustus <foo@auggie.dev>