### PR TITLE
.github/settings.yml: Resolve configuration drift

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -23,12 +23,15 @@ repository:
 
 # See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
 teams:
-  - name: functionclarity-admins
+  - name: org-admins
     # The permission to grant the team. Can be one of:
     # * `pull` - can pull, but not push to or administer this repository.
     # * `push` - can pull and push, but not administer this repository.
     # * `admin` - can pull, push and administer this repository.
     # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+    permission: admin
+
+  - name: functionclarity-admins
     permission: admin
 
   - name: functionclarity-maintainers
@@ -59,8 +62,11 @@ branches:
       required_status_checks:
         # Required. Require branches to be up to date before merging.
         strict: true
-        # Required. The list of status checks to require in order to merge into this branch
-        contexts: []
+        checks:
+          - context: build
+          - context: verify
+          # TODO(settings): Uncomment once https://github.com/openclarity/functionclarity/issues/69 is addressed.
+          #- context: test
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
       # Prevent merge commits from being pushed to matching branches


### PR DESCRIPTION
Follow-up to https://github.com/openclarity/functionclarity/pull/112.

- Ensure `org-admins` team has admin access to repo
- Set `build` and `verify` as required status checks

Signed-off-by: Stephen Augustus <foo@auggie.dev>